### PR TITLE
Remove dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,6 @@ updates:
       timezone: "Europe/Paris"
     labels:
       - "dependencie"
-    groups:
-      production-dependencies:
-        dependency-type: "production"
-      development-dependencies:
-        dependency-type: "development"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
- Remove dependabot config responsible for merging multiple package updates in one pull request